### PR TITLE
Iss#58

### DIFF
--- a/app/src/debug/res/values/google_maps_api.xml
+++ b/app/src/debug/res/values/google_maps_api.xml
@@ -20,5 +20,5 @@
     Once you have your key (it starts with "AIza"), replace the "google_maps_key"
     string in this file.
     -->
-    <string name="google_maps_key" templateMergeStrategy="preserve" translatable="false">AIzaSyAfWtPgHE9laRceRKHdMwc-EHBT-9H6fsA</string>
+    <string name="google_maps_key" templateMergeStrategy="preserve" translatable="false">AIzaSyC1iE7MU8R78okNvy6SKGeqIcTy8pJrOIs</string>
 </resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,7 +38,7 @@
         -->
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="AIzaSyAfWtPgHE9laRceRKHdMwc-EHBT-9H6fsA" />
+            android:value="AIzaSyC1iE7MU8R78okNvy6SKGeqIcTy8pJrOIs" />
 
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/com/example/sukima_android/SkimattiClient.kt
+++ b/app/src/main/java/com/example/sukima_android/SkimattiClient.kt
@@ -1,8 +1,6 @@
 package com.example.sukima_android
 
-import com.example.sukima_android.model.Spots
-import com.example.sukima_android.model.User
-import com.example.sukima_android.model.post_user
+import com.example.sukima_android.model.*
 import retrofit2.http.*
 
 interface SkimattiClient {
@@ -20,4 +18,11 @@ interface SkimattiClient {
      suspend fun postUser(
     @Body postUser: post_user
     ):User
+
+    @Headers("Content-Type: application/json")
+    @POST("/users/{user_id}/visited")
+    suspend fun postVisited(
+        @Path("user_id") user_id:Int,
+        @Body visited: visited_data?
+    ): Visit_res
 }

--- a/app/src/main/java/com/example/sukima_android/model/Visited.kt
+++ b/app/src/main/java/com/example/sukima_android/model/Visited.kt
@@ -1,0 +1,12 @@
+package com.example.sukima_android.model
+
+import java.io.Serializable
+
+data class Visit_res(
+val spot_id:Int
+)
+
+data class visited_data (
+    val spot_id : Int,
+    val session_id : String
+)


### PR DESCRIPTION
#関連issue#
checkinするとマップからピンが消えます

#やったこと#
checkin画面（dialog）でいってみる（ikuiyo）を押すとVisitedのPOSTを実効するようにした
スポットIDとセッションIDをもっているvisited_dataを新たに生成

#注意点#
チェックインして行ってみるヲ押すとそのIDのユーザのスポットからチェックインしたスポットが消えるようになっている。